### PR TITLE
Adujst tests to using SWX Advisory issuing center type instead of designator

### DIFF
--- a/src/test/java/fi/fmi/avi/converter/iwxxm/v3_0/SpaceWeatherIWXXMParserTest.java
+++ b/src/test/java/fi/fmi/avi/converter/iwxxm/v3_0/SpaceWeatherIWXXMParserTest.java
@@ -100,8 +100,7 @@ public class SpaceWeatherIWXXMParserTest extends DOMParsingTestBase {
         assertTrue(result.getConvertedMessage().isPresent());
 
         final SpaceWeatherAdvisory swx = result.getConvertedMessage().get();
-        assertEquals("DONLON WEATHER FORECAST CENTER", swx.getIssuingCenter().getName().get());
-        assertEquals("DONLON", swx.getIssuingCenter().getDesignator().get());
+        assertEquals("DONLON", swx.getIssuingCenter().getName().get());
         assertEquals("OTHER:SWXC", swx.getIssuingCenter().getType().get());
         assertEquals(2016, swx.getAdvisoryNumber().getYear());
         assertEquals(2, swx.getAdvisoryNumber().getSerialNumber());
@@ -154,8 +153,7 @@ public class SpaceWeatherIWXXMParserTest extends DOMParsingTestBase {
         assertTrue(result.getConvertedMessage().isPresent());
 
         final SpaceWeatherAdvisory swx = result.getConvertedMessage().get();
-        assertEquals("DONLON WEATHER FORECAST CENTER", swx.getIssuingCenter().getName().get());
-        assertEquals("DONLON", swx.getIssuingCenter().getDesignator().get());
+        assertEquals("DONLON", swx.getIssuingCenter().getName().get());
         assertEquals("OTHER:SWXC", swx.getIssuingCenter().getType().get());
         assertEquals(2016, swx.getAdvisoryNumber().getYear());
         assertEquals(2, swx.getAdvisoryNumber().getSerialNumber());
@@ -210,8 +208,7 @@ public class SpaceWeatherIWXXMParserTest extends DOMParsingTestBase {
         assertTrue(result.getConvertedMessage().isPresent());
 
         final SpaceWeatherAdvisory swx = result.getConvertedMessage().get();
-        assertEquals("DONLON WEATHER FORECAST CENTER", swx.getIssuingCenter().getName().get());
-        assertEquals("DONLON", swx.getIssuingCenter().getDesignator().get());
+        assertEquals("DONLON", swx.getIssuingCenter().getName().get());
         assertEquals("OTHER:SWXC", swx.getIssuingCenter().getType().get());
         assertEquals(2016, swx.getAdvisoryNumber().getYear());
         assertEquals(2, swx.getAdvisoryNumber().getSerialNumber());
@@ -249,7 +246,7 @@ public class SpaceWeatherIWXXMParserTest extends DOMParsingTestBase {
 
         final SpaceWeatherAdvisory swx = result.getConvertedMessage().get();
         assertEquals("ACFJ", swx.getIssuingCenter().getName().get());
-        assertEquals("SWXC", swx.getIssuingCenter().getDesignator().get());
+        assertEquals("OTHER:SWXC", swx.getIssuingCenter().getType().get());
         assertEquals(2016, swx.getAdvisoryNumber().getYear());
         assertEquals(2, swx.getAdvisoryNumber().getSerialNumber());
         assertEquals(ZonedDateTime.parse("2016-11-08T01:00Z"), swx.getIssueTime().get().getCompleteTime().get());

--- a/src/test/java/fi/fmi/avi/converter/iwxxm/v3_0/SpaceWeatherIWXXMSerializerTest.java
+++ b/src/test/java/fi/fmi/avi/converter/iwxxm/v3_0/SpaceWeatherIWXXMSerializerTest.java
@@ -125,6 +125,17 @@ public class SpaceWeatherIWXXMSerializerTest {
     }
 
     @Test
+    public void serialize_spacewx_issuing_centre() throws Exception {
+        final String input = getInput("spacewx-issuing-centre.json");
+        final ConversionResult<String> result = serialize(input);
+
+        assertEquals(ConversionResult.Status.SUCCESS, result.getStatus());
+        assertTrue(result.getConvertedMessage().isPresent());
+        assertNotNull(result.getConvertedMessage().get());
+        assertEqualsXML(getInput("spacewx-issuing-centre.xml"), result.getConvertedMessage().get());
+    }
+
+    @Test
     public void parse_and_serialize_test_A2_3() throws Exception {
         testParseAndSerialize("spacewx-A2-3.xml");
     }

--- a/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-A2-3.json
+++ b/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-A2-3.json
@@ -3,8 +3,7 @@
     "completeTime": "2016-11-08T01:00:00Z"
   },
   "issuingCenter": {
-    "name": "DONLON WEATHER FORECAST CENTER",
-    "designator": "DONLON",
+    "name": "DONLON",
     "type": "OTHER:SWXC"
   },
   "advisoryNumber": {

--- a/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-A2-3.xml
+++ b/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-A2-3.xml
@@ -23,9 +23,8 @@
         <aixm:UnitTimeSlice gml:id="uuid.64f29fac-154b-4484-a49d-7c8816e4840c">
           <gml:validTime />
           <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-          <aixm:name>DONLON WEATHER FORECAST CENTER</aixm:name>
+          <aixm:name>DONLON</aixm:name>
           <aixm:type>OTHER:SWXC</aixm:type>
-          <aixm:designator>DONLON</aixm:designator>
         </aixm:UnitTimeSlice>
       </aixm:timeSlice>
     </aixm:Unit>

--- a/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-A2-4.json
+++ b/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-A2-4.json
@@ -3,8 +3,7 @@
     "completeTime": "2016-11-08T00:00:00Z"
   },
   "issuingCenter": {
-    "name": "DONLON WEATHER FORECAST CENTER",
-    "designator": "DONLON",
+    "name": "DONLON",
     "type": "OTHER:SWXC"
   },
   "advisoryNumber": {

--- a/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-A2-4.xml
+++ b/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-A2-4.xml
@@ -23,9 +23,8 @@
         <aixm:UnitTimeSlice gml:id="uuid.64f29fac-154b-4484-a49d-7c8816e4840c">
           <gml:validTime />
           <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-          <aixm:name>DONLON WEATHER FORECAST CENTER</aixm:name>
+          <aixm:name>DONLON</aixm:name>
           <aixm:type>OTHER:SWXC</aixm:type>
-          <aixm:designator>DONLON</aixm:designator>
         </aixm:UnitTimeSlice>
       </aixm:timeSlice>
     </aixm:Unit>

--- a/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-A2-5.json
+++ b/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-A2-5.json
@@ -3,8 +3,7 @@
     "completeTime": "2016-11-08T00:00:00Z"
   },
   "issuingCenter": {
-    "name": "DONLON WEATHER FORECAST CENTER",
-    "designator": "DONLON",
+    "name": "DONLON",
     "type": "OTHER:SWXC"
   },
   "advisoryNumber": {

--- a/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-A2-5.xml
+++ b/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-A2-5.xml
@@ -22,9 +22,8 @@
         <aixm:UnitTimeSlice gml:id="uuid.64f29fac-154b-4484-a49d-7c8816e4840c">
           <gml:validTime />
           <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-          <aixm:name>DONLON WEATHER FORECAST CENTER</aixm:name>
+          <aixm:name>DONLON</aixm:name>
           <aixm:type>OTHER:SWXC</aixm:type>
-          <aixm:designator>DONLON</aixm:designator>
         </aixm:UnitTimeSlice>
       </aixm:timeSlice>
     </aixm:Unit>

--- a/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-daylight-side-nil-location.json
+++ b/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-daylight-side-nil-location.json
@@ -3,8 +3,8 @@
     "completeTime": "2016-11-08T01:00:00Z"
   },
   "issuingCenter": {
-    "designator": "SWXC",
-    "name": "ACFJ"
+    "name": "ACFJ",
+    "type": "OTHER:SWXC"
   },
   "advisoryNumber": {
     "year": 2016,

--- a/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-daylight-side-nil-location.xml
+++ b/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-daylight-side-nil-location.xml
@@ -20,7 +20,7 @@
           <gml:validTime />
           <aixm:interpretation>SNAPSHOT</aixm:interpretation>
           <aixm:name>ACFJ</aixm:name>
-          <aixm:designator>SWXC</aixm:designator>
+          <aixm:type>OTHER:SWXC</aixm:type>
         </aixm:UnitTimeSlice>
       </aixm:timeSlice>
     </aixm:Unit>

--- a/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-issuing-centre.json
+++ b/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-issuing-centre.json
@@ -1,0 +1,65 @@
+{
+  "issueTime": {
+    "completeTime": "2016-11-08T00:00:00Z"
+  },
+  "issuingCenter": {
+    "name": "SWXC NAME",
+    "designator": "DESIGNATOR",
+    "type": "OTHER:SWXCTEST"
+  },
+  "advisoryNumber": {
+    "year": 2016,
+    "serialNumber": 2
+  },
+  "phenomena": [
+    "RADIATION_MOD"
+  ],
+  "analyses": [
+    {
+      "time": {
+        "completeTime": "2016-11-08T01:00:00Z"
+      },
+      "analysisType": "OBSERVATION",
+      "regions": [],
+      "nilPhenomenonReason": "NO_PHENOMENON_EXPECTED"
+    },
+    {
+      "time": {
+        "completeTime": "2016-11-08T07:00:00Z"
+      },
+      "analysisType": "FORECAST",
+      "regions": [],
+      "nilPhenomenonReason": "NO_PHENOMENON_EXPECTED"
+    },
+    {
+      "time": {
+        "completeTime": "2016-11-08T13:00:00Z"
+      },
+      "analysisType": "FORECAST",
+      "regions": [],
+      "nilPhenomenonReason": "NO_PHENOMENON_EXPECTED"
+    },
+    {
+      "time": {
+        "completeTime": "2016-11-08T19:00:00Z"
+      },
+      "analysisType": "FORECAST",
+      "regions": [],
+      "nilPhenomenonReason": "NO_PHENOMENON_EXPECTED"
+    },
+    {
+      "time": {
+        "completeTime": "2016-11-09T01:00:00Z"
+      },
+      "analysisType": "FORECAST",
+      "regions": [],
+      "nilPhenomenonReason": "NO_PHENOMENON_EXPECTED"
+    }
+  ],
+  "nextAdvisory": {
+    "timeSpecifier": "NO_FURTHER_ADVISORIES"
+  },
+  "permissibleUsage": "NON_OPERATIONAL",
+  "permissibleUsageReason": "TEST",
+  "reportStatus": "NORMAL"
+}

--- a/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-issuing-centre.xml
+++ b/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/spacewx-issuing-centre.xml
@@ -8,11 +8,13 @@
   xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0/iwxxm.xsd"
   gml:id="uuid.dea6234c-f57f-4ccf-be7a-bb00a0265af2"
   reportStatus="NORMAL"
-  permissibleUsage="OPERATIONAL">
+  permissibleUsage="NON-OPERATIONAL"
+  permissibleUsageReason="TEST"
+>
 
   <iwxxm:issueTime>
     <gml:TimeInstant gml:id="uuid.161d2ad1-e945-4213-84a7-8f9c2c57540f">
-      <gml:timePosition>2016-11-08T01:00:00Z</gml:timePosition>
+      <gml:timePosition>2016-11-08T00:00:00Z</gml:timePosition>
     </gml:TimeInstant>
   </iwxxm:issueTime>
 
@@ -22,8 +24,9 @@
         <aixm:UnitTimeSlice gml:id="uuid.64f29fac-154b-4484-a49d-7c8816e4840c">
           <gml:validTime />
           <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-          <aixm:name>DONLON</aixm:name>
-          <aixm:type>OTHER:SWXC</aixm:type>
+          <aixm:name>SWXC NAME</aixm:name>
+          <aixm:designator>DESIGNATOR</aixm:designator>
+          <aixm:type>OTHER:SWXCTEST</aixm:type>
         </aixm:UnitTimeSlice>
       </aixm:timeSlice>
     </aixm:Unit>
@@ -31,10 +34,7 @@
 
   <iwxxm:advisoryNumber>2016/2</iwxxm:advisoryNumber>
 
-  <iwxxm:replacedAdvisoryNumber>2016/1</iwxxm:replacedAdvisoryNumber>
-
-  <iwxxm:phenomenon xlink:href="http://codes.wmo.int/49-2/SpaceWxPhenomena/HF_COM_MOD" />
-  <iwxxm:phenomenon xlink:href="http://codes.wmo.int/49-2/SpaceWxPhenomena/GNSS_MOD" />
+  <iwxxm:phenomenon xlink:href="http://codes.wmo.int/49-2/SpaceWxPhenomena/RADIATION_MOD" />
 
   <iwxxm:analysis>
     <iwxxm:SpaceWeatherAnalysis gml:id="uuid.e10181fb-ff0a-40cf-865c-bb209fc49b90" timeIndicator="OBSERVATION">
@@ -43,52 +43,7 @@
           <gml:timePosition>2016-11-08T01:00:00Z</gml:timePosition>
         </gml:TimeInstant>
       </iwxxm:phenomenonTime>
-      <iwxxm:region>
-        <iwxxm:SpaceWeatherRegion gml:id="uuid.186a603f-7a4a-4873-9ec7-29faccd2015e">
-          <iwxxm:location>
-            <aixm:AirspaceVolume gml:id="uuid.7138f8d1-9854-46cb-a1b1-9d96c5cee46f">
-              <aixm:horizontalProjection>
-                <aixm:Surface gml:id="uuid.3b00652b-4bed-4655-959c-1c9efd431cac" srsDimension="2" axisLabels="Lat Lon"
-                  srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                  <gml:patches>
-                    <gml:PolygonPatch>
-                      <gml:exterior>
-                        <gml:LinearRing>
-                          <gml:posList>-180 90 -180 60 180 60 180 90 -180 90</gml:posList>
-                        </gml:LinearRing>
-                      </gml:exterior>
-                    </gml:PolygonPatch>
-                  </gml:patches>
-                </aixm:Surface>
-              </aixm:horizontalProjection>
-            </aixm:AirspaceVolume>
-          </iwxxm:location>
-          <iwxxm:locationIndicator xlink:href="http://codes.wmo.int/49-2/SpaceWxLocation/HNH" />
-        </iwxxm:SpaceWeatherRegion>
-      </iwxxm:region>
-      <iwxxm:region>
-        <iwxxm:SpaceWeatherRegion gml:id="uuid.529da7b6-3512-4418-a84e-3267f57f36eb">
-          <iwxxm:location>
-            <aixm:AirspaceVolume gml:id="uuid.e5094671-591f-47ec-9a34-277287d876b4">
-              <aixm:horizontalProjection>
-                <aixm:Surface gml:id="uuid.3ecfcac7-006e-4279-9798-c21abf12d648" srsDimension="2" axisLabels="Lat Lon"
-                  srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
-                  <gml:patches>
-                    <gml:PolygonPatch>
-                      <gml:exterior>
-                        <gml:LinearRing>
-                          <gml:posList>-180 -90 -180 -60 180 -60 180 -90 -180 -90</gml:posList>
-                        </gml:LinearRing>
-                      </gml:exterior>
-                    </gml:PolygonPatch>
-                  </gml:patches>
-                </aixm:Surface>
-              </aixm:horizontalProjection>
-            </aixm:AirspaceVolume>
-          </iwxxm:location>
-          <iwxxm:locationIndicator xlink:href="http://codes.wmo.int/49-2/SpaceWxLocation/HSH" />
-        </iwxxm:SpaceWeatherRegion>
-      </iwxxm:region>
+      <iwxxm:region nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance" />
     </iwxxm:SpaceWeatherAnalysis>
   </iwxxm:analysis>
 
@@ -99,8 +54,7 @@
           <gml:timePosition>2016-11-08T07:00:00Z</gml:timePosition>
         </gml:TimeInstant>
       </iwxxm:phenomenonTime>
-      <iwxxm:region xlink:href="#uuid.186a603f-7a4a-4873-9ec7-29faccd2015e" />
-      <iwxxm:region xlink:href="#uuid.529da7b6-3512-4418-a84e-3267f57f36eb" />
+      <iwxxm:region nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance" />
     </iwxxm:SpaceWeatherAnalysis>
   </iwxxm:analysis>
 
@@ -111,8 +65,7 @@
           <gml:timePosition>2016-11-08T13:00:00Z</gml:timePosition>
         </gml:TimeInstant>
       </iwxxm:phenomenonTime>
-      <iwxxm:region xlink:href="#uuid.186a603f-7a4a-4873-9ec7-29faccd2015e" />
-      <iwxxm:region xlink:href="#uuid.529da7b6-3512-4418-a84e-3267f57f36eb" />
+      <iwxxm:region nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance" />
     </iwxxm:SpaceWeatherAnalysis>
   </iwxxm:analysis>
 
@@ -123,8 +76,7 @@
           <gml:timePosition>2016-11-08T19:00:00Z</gml:timePosition>
         </gml:TimeInstant>
       </iwxxm:phenomenonTime>
-      <iwxxm:region xlink:href="#uuid.186a603f-7a4a-4873-9ec7-29faccd2015e" />
-      <iwxxm:region xlink:href="#uuid.529da7b6-3512-4418-a84e-3267f57f36eb" />
+      <iwxxm:region nilReason="http://codes.wmo.int/common/nil/nothingOfOperationalSignificance" />
     </iwxxm:SpaceWeatherAnalysis>
   </iwxxm:analysis>
 
@@ -139,8 +91,7 @@
     </iwxxm:SpaceWeatherAnalysis>
   </iwxxm:analysis>
 
-  <iwxxm:remarks nilReason="http://codes.wmo.int/common/nil/inapplicable"/>
+  <iwxxm:remarks nilReason="http://codes.wmo.int/common/nil/inapplicable" />
 
   <iwxxm:nextAdvisoryTime nilReason="http://codes.wmo.int/common/nil/inapplicable" />
-
 </iwxxm:SpaceWeatherAdvisory>

--- a/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/swx-bulletin.xml
+++ b/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/swx-bulletin.xml
@@ -28,9 +28,8 @@
             <aixm:UnitTimeSlice gml:id="uuid.64f29fac-154b-4484-a49d-7c8816e4840c">
               <gml:validTime />
               <aixm:interpretation>SNAPSHOT</aixm:interpretation>
-              <aixm:name>DONLON WEATHER FORECAST CENTER</aixm:name>
+              <aixm:name>DONLON</aixm:name>
               <aixm:type>OTHER:SWXC</aixm:type>
-              <aixm:designator>DONLON</aixm:designator>
             </aixm:UnitTimeSlice>
           </aixm:timeSlice>
         </aixm:Unit>


### PR DESCRIPTION
Fixes fmidev/fmi-avi-messageconverter-tac#92 on iwxxm tests.