### PR TITLE
Changelog, parent pom and dependency update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,14 +35,25 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Added generic POJO conversion for IWXXM 3.0.0 messages. [#80]
+- Added support for IWXXM 3.0.0 messages withing COLLECT documents. [#80]
 - Added parsing of all SIGMET location indicators to GenericAviationWeatherMessage. [#84]
+- Added parsing of message translation status from IWXXM Message [#91]
+- Added parsing of xmlNamespace in GenericAviationWeatherMessage [#92]
+- Added parsing of generic IWXXM 3.0 METAR messages [#94]
+- Added parsing of generic IWXXM 3.0 SPECI messages [#96]
+- Added parsing of generic IWXXM 3.0 SPACE WEATHER ADVISORY messages [#97]
+- Added parsing of generic IWXXM 3.0 AIRMET messages [#101]
+- Added parsing of generic IWXXM 3.0 Tropical cyclone advisory messages [#106]
+- Added parsing of generic IWXXM 3.0 Volcanic ash advisory messages [#107]
 
 ### Changed
 
 - Adapted to location indicator model changes in GenericAviationMessage. [#82]
 - Separated generic message parsing from generic bulletin parsing. [#83]
 - Split GenericAviationWeatherMessageScanner into IWXXM version- and message-specific scanners. [#88]
+
+### Fixed
+- Declare all required namespaces in root element of message document extracted from a COLLECT document [#110]
 
 ## [v3.0.0] - 2021-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,20 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - ...
 
-## [v3.0.0] - 2014-04-13
+## [v4.0.0] - 2022-02-22
+
+### Added
+
+- Added generic POJO conversion for IWXXM 3.0.0 messages. [#80]
+- Added parsing of all SIGMET location indicators to GenericAviationWeatherMessage. [#84]
+
+### Changed
+
+- Adapted to location indicator model changes in GenericAviationMessage. [#82]
+- Separated generic message parsing from generic bulletin parsing. [#83]
+- Split GenericAviationWeatherMessageScanner into IWXXM version- and message-specific scanners. [#88]
+
+## [v3.0.0] - 2021-04-13
 
 ### Added
 
@@ -51,7 +64,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Previous changelog entries are available on [GitHub releases page](https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/releases) in a more freeform format.
 
-[Unreleased]: https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/compare/fmi-avi-messageconverter-iwxxm-3.0.0...HEAD
+[Unreleased]: https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/compare/fmi-avi-messageconverter-iwxxm-4.0.0...HEAD
+
+[v4.0.0]: https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/releases/tag/fmi-avi-messageconverter-iwxxm-4.0.0
 
 [v3.0.0]: https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/releases/tag/fmi-avi-messageconverter-iwxxm-3.0.0
 
@@ -70,3 +85,13 @@ Previous changelog entries are available on [GitHub releases page](https://githu
 [#72]:https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/issues/72
 
 [#74]:https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/issues/74
+
+[#80]:https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/issues/80
+
+[#82]:https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/issues/82
+
+[#83]:https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/issues/83
+
+[#84]:https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/issues/84
+
+[#88]:https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/issues/88

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Adapted to location indicator model changes in GenericAviationMessage. [#82]
 - Separated generic message parsing from generic bulletin parsing. [#83]
 - Split GenericAviationWeatherMessageScanner into IWXXM version- and message-specific scanners. [#88]
+- Depend on fmi-avi-messageconverter:6.0.0
 
 ### Fixed
 - Declare all required namespaces in root element of message document extracted from a COLLECT document [#110]
@@ -106,3 +107,21 @@ Previous changelog entries are available on [GitHub releases page](https://githu
 [#84]:https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/issues/84
 
 [#88]:https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/issues/88
+
+[#91]: https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/issues/91
+
+[#92]: https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/issues/92
+
+[#94]: https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/issues/94
+
+[#96]: https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/issues/96
+
+[#97]: https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/issues/97
+
+[#101]: https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/issues/101
+
+[#106]: https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/issues/106
+
+[#107]: https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/issues/107
+
+[#110]: https://github.com/fmidev/fmi-avi-messageconverter-iwxxm/issues/110

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>fi.fmi.avi.converter</groupId>
       <artifactId>fmi-avi-messageconverter</artifactId>
-      <version>5.0.2-arch10-SNAPSHOT</version>
+      <version>6.0.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>fi.fmi</groupId>
     <artifactId>fmi-os-parent-pom</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Depends on fmidev/fmi-avi-messageconverter/pull/98, fmidev/fmi-avi-messageconverter/pull/99 + 6.0.0 release