### PR TITLE
Add support for minimal test SIGMET/AIRMET messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>fi.fmi.avi.converter</groupId>
             <artifactId>fmi-avi-messageconverter</artifactId>
-            <version>7.0.0-beta1</version>
+            <version>7.0.0-beta2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>fi.fmi.xmlmodel</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <description>Aviation weather message conversions - IWXXM module</description>
     <groupId>fi.fmi.avi.converter</groupId>
     <artifactId>fmi-avi-messageconverter-iwxxm</artifactId>
-    <version>5.0.0-beta2-SNAPSHOT</version>
+    <version>5.0.0-beta3-SNAPSHOT</version>
 
     <scm>
         <connection>scm:git:https://github.com/fmidev/fmi-avi-messageconverter-iwxxm.git</connection>
@@ -22,22 +22,27 @@
         <dependency>
             <groupId>fi.fmi.avi.converter</groupId>
             <artifactId>fmi-avi-messageconverter</artifactId>
-            <version>7.0.0-beta2-SNAPSHOT</version>
+            <version>7.0.0-beta3-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>fi.fmi.xmlmodel</groupId>
             <artifactId>fmi-avi-xmlmodel-iwxxm211</artifactId>
-            <version>1.5.0</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>fi.fmi.xmlmodel</groupId>
             <artifactId>fmi-avi-xmlmodel-iwxxm30</artifactId>
-            <version>1.5.0</version>
+            <version>2.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>fi.fmi.xmlmodel</groupId>
+            <artifactId>fmi-avi-xmlmodel-iwxxm2023-1</artifactId>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>fi.fmi.xmlmodel</groupId>
             <artifactId>fmi-avi-xmlmodel-wmo-collect2014</artifactId>
-            <version>1.5.0</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>net.sf.saxon</groupId>

--- a/src/main/java/fi/fmi/avi/converter/iwxxm/v2023_1/airmet/AIRMETIWXXMSerializer.java
+++ b/src/main/java/fi/fmi/avi/converter/iwxxm/v2023_1/airmet/AIRMETIWXXMSerializer.java
@@ -232,9 +232,9 @@ public abstract class AIRMETIWXXMSerializer<T> extends AbstractIWXXM20231Seriali
                     ecct.setPhenomenonTime(phenTimeProp);
                     ecct.setId(getUUID());
                     for (PhenomenonGeometryWithHeight an : ans) {
-                        if (an.getAnalysisType().equals(SigmetAnalysisType.FORECAST)) {
+                        if (an.getAnalysisType().orElse(null) == SigmetAnalysisType.FORECAST) {
                             ecct.setTimeIndicator(TimeIndicatorType.FORECAST);
-                        } else if (an.getAnalysisType().equals(SigmetAnalysisType.OBSERVATION)) {
+                        } else if (an.getAnalysisType().orElse(null) == SigmetAnalysisType.OBSERVATION) {
                             ecct.setTimeIndicator(TimeIndicatorType.OBSERVATION);
                         } else {
                             ecct.setTimeIndicator(null);

--- a/src/main/java/fi/fmi/avi/converter/iwxxm/v2023_1/sigmet/SIGMETIWXXMSerializer.java
+++ b/src/main/java/fi/fmi/avi/converter/iwxxm/v2023_1/sigmet/SIGMETIWXXMSerializer.java
@@ -318,7 +318,7 @@ public abstract class SIGMETIWXXMSerializer<T> extends AbstractIWXXM20231Seriali
             if (hasAnalaysisGeometries || hasForecasts) {
                 final String analysisTime = input.getAnalysisGeometries()//
                         .map(AbstractIWXXM20231Serializer::getFirstOrNull)//
-                        .flatMap(PhenomenonGeometryWithHeight::getTime)//
+                        .flatMap(PhenomenonGeometry::getTime)//
                         .flatMap(AbstractIWXXMSerializer::toIWXXMDateTime)//
                         .orElse(null);
 

--- a/src/main/java/fi/fmi/avi/converter/iwxxm/v2_1/sigmet/SIGMETIWXXMSerializer.java
+++ b/src/main/java/fi/fmi/avi/converter/iwxxm/v2_1/sigmet/SIGMETIWXXMSerializer.java
@@ -1,5 +1,38 @@
 package fi.fmi.avi.converter.iwxxm.v2_1.sigmet;
 
+import aero.aixm511.*;
+import fi.fmi.avi.converter.*;
+import fi.fmi.avi.converter.ConversionResult.Status;
+import fi.fmi.avi.converter.iwxxm.AbstractIWXXMSerializer;
+import fi.fmi.avi.converter.iwxxm.ReferredObjectRetrievalContext;
+import fi.fmi.avi.converter.iwxxm.XMLSchemaInfo;
+import fi.fmi.avi.converter.iwxxm.v2_1.AbstractIWXXM21Serializer;
+import fi.fmi.avi.model.*;
+import fi.fmi.avi.model.sigmet.SIGMET;
+import fi.fmi.avi.model.sigmet.SigmetAnalysisType;
+import fi.fmi.avi.model.sigmet.VAInfo;
+import icao.iwxxm21.AirspacePropertyType;
+import icao.iwxxm21.UnitPropertyType;
+import icao.iwxxm21.*;
+import net.opengis.gml32.PointPropertyType;
+import net.opengis.gml32.PointType;
+import net.opengis.gml32.*;
+import net.opengis.om20.OMObservationPropertyType;
+import net.opengis.om20.OMObservationType;
+import net.opengis.om20.OMProcessPropertyType;
+import net.opengis.om20.TimeObjectPropertyType;
+import net.opengis.sampling.spatial.SFSpatialSamplingFeatureType;
+import net.opengis.sampling.spatial.ShapeType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import wmo.metce2013.ProcessType;
+import wmo.metce2013.VolcanoPropertyType;
+import wmo.metce2013.VolcanoType;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
 import java.io.InputStream;
 import java.math.BigInteger;
 import java.time.ZonedDateTime;
@@ -9,101 +42,12 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
 
-import javax.xml.bind.JAXBElement;
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
-
-import net.opengis.gml32.AbstractTimeObjectType;
-import net.opengis.gml32.DirectPositionType;
-import net.opengis.gml32.FeaturePropertyType;
-import net.opengis.gml32.PointPropertyType;
-import net.opengis.gml32.PointType;
-import net.opengis.gml32.ReferenceType;
-import net.opengis.gml32.SpeedType;
-import net.opengis.gml32.StringOrRefType;
-import net.opengis.gml32.TimeInstantPropertyType;
-import net.opengis.gml32.TimeInstantType;
-import net.opengis.gml32.TimePeriodPropertyType;
-import net.opengis.gml32.TimePeriodType;
-import net.opengis.gml32.TimePositionType;
-import net.opengis.gml32.TimePrimitivePropertyType;
-import net.opengis.om20.OMObservationPropertyType;
-import net.opengis.om20.OMObservationType;
-import net.opengis.om20.OMProcessPropertyType;
-import net.opengis.om20.TimeObjectPropertyType;
-import net.opengis.sampling.spatial.SFSpatialSamplingFeatureType;
-import net.opengis.sampling.spatial.ShapeType;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-
-import aero.aixm511.AirspaceTimeSlicePropertyType;
-import aero.aixm511.AirspaceTimeSliceType;
-import aero.aixm511.AirspaceType;
-import aero.aixm511.AirspaceVolumePropertyType;
-import aero.aixm511.AirspaceVolumeType;
-import aero.aixm511.CodeAirspaceDesignatorType;
-import aero.aixm511.CodeAirspaceType;
-import aero.aixm511.CodeOrganisationDesignatorType;
-import aero.aixm511.CodeUnitType;
-import aero.aixm511.CodeVerticalReferenceType;
-import aero.aixm511.TextNameType;
-import aero.aixm511.UnitTimeSlicePropertyType;
-import aero.aixm511.UnitTimeSliceType;
-import aero.aixm511.UnitType;
-import fi.fmi.avi.converter.ConversionException;
-import fi.fmi.avi.converter.ConversionHints;
-import fi.fmi.avi.converter.ConversionIssue;
-import fi.fmi.avi.converter.ConversionResult;
-import fi.fmi.avi.converter.ConversionResult.Status;
-import fi.fmi.avi.converter.IssueList;
-import fi.fmi.avi.converter.iwxxm.AbstractIWXXMSerializer;
-import fi.fmi.avi.converter.iwxxm.ReferredObjectRetrievalContext;
-import fi.fmi.avi.converter.iwxxm.XMLSchemaInfo;
-import fi.fmi.avi.converter.iwxxm.v2_1.AbstractIWXXM21Serializer;
-import fi.fmi.avi.model.AviationCodeListUser;
-import fi.fmi.avi.model.NumericMeasure;
-import fi.fmi.avi.model.PartialOrCompleteTimeInstant;
-import fi.fmi.avi.model.PartialOrCompleteTimePeriod;
-import fi.fmi.avi.model.PhenomenonGeometry;
-import fi.fmi.avi.model.PhenomenonGeometryWithHeight;
-import fi.fmi.avi.model.TacOrGeoGeometry;
-import fi.fmi.avi.model.VolcanoDescription;
-import fi.fmi.avi.model.sigmet.SIGMET;
-import fi.fmi.avi.model.sigmet.SigmetAnalysisType;
-import fi.fmi.avi.model.sigmet.VAInfo;
-import icao.iwxxm21.AeronauticalSignificantWeatherPhenomenonType;
-import icao.iwxxm21.AirspacePropertyType;
-import icao.iwxxm21.AngleWithNilReasonType;
-import icao.iwxxm21.ExpectedIntensityChangeType;
-import icao.iwxxm21.PermissibleUsageReasonType;
-import icao.iwxxm21.PermissibleUsageType;
-import icao.iwxxm21.RelationalOperatorType;
-import icao.iwxxm21.SIGMETEvolvingConditionCollectionPropertyType;
-import icao.iwxxm21.SIGMETEvolvingConditionCollectionType;
-import icao.iwxxm21.SIGMETEvolvingConditionPropertyType;
-import icao.iwxxm21.SIGMETEvolvingConditionType;
-import icao.iwxxm21.SIGMETPositionCollectionPropertyType;
-import icao.iwxxm21.SIGMETPositionCollectionType;
-import icao.iwxxm21.SIGMETPositionPropertyType;
-import icao.iwxxm21.SIGMETPositionType;
-import icao.iwxxm21.SIGMETReportStatusType;
-import icao.iwxxm21.SIGMETType;
-import icao.iwxxm21.TimeIndicatorType;
-import icao.iwxxm21.TropicalCycloneSIGMETType;
-import icao.iwxxm21.UnitPropertyType;
-import icao.iwxxm21.VolcanicAshSIGMETType;
-import wmo.metce2013.ProcessType;
-import wmo.metce2013.VolcanoPropertyType;
-import wmo.metce2013.VolcanoType;
-
 public abstract class SIGMETIWXXMSerializer<T> extends AbstractIWXXM21Serializer<SIGMET, T> {
     private static final Logger LOG = LoggerFactory.getLogger(SIGMETIWXXMSerializer.class);
 
     @SuppressWarnings("unchecked")
     private static OMObservationPropertyType createForecastPositionAnalysis(final SIGMET inputs, final String designator, final String issueTime,
-            final String sigmetUUID) {
+                                                                            final String sigmetUUID) {
         return create(OMObservationPropertyType.class, omObsType -> omObsType.setOMObservation(create(OMObservationType.class, omObs -> {
             omObs.setId("forecastPositionAnalysis-" + sigmetUUID);
             omObs.setType(create(ReferenceType.class, ref -> ref.setHref(AviationCodeListUser.CODELIST_SIGMET_POSITION_COLLECTION_ANALYSIS)));
@@ -515,7 +459,7 @@ public abstract class SIGMETIWXXMSerializer<T> extends AbstractIWXXM21Serializer
                     .flatMap(PhenomenonGeometry::getTime)//
                     .<String> flatMap(AbstractIWXXMSerializer::toIWXXMDateTime)//
                     .orElse(null);
-            if (input.getAnalysisGeometries().get().get(0).getAnalysisType() == SigmetAnalysisType.UNKNOWN || analysisTime == null) {
+            if (!input.getAnalysisGeometries().get().get(0).getAnalysisType().isPresent() || analysisTime == null) {
                 //set Phen time to nil with nilReason of "missing"
                 omObs.setPhenomenonTime(
                         create(TimeObjectPropertyType.class, toProp -> toProp.getNilReason().add(AviationCodeListUser.CODELIST_VALUE_NIL_REASON_MISSING)));
@@ -584,7 +528,7 @@ public abstract class SIGMETIWXXMSerializer<T> extends AbstractIWXXM21Serializer
                 seccpt -> seccpt.setSIGMETEvolvingConditionCollection(create(SIGMETEvolvingConditionCollectionType.class, secct -> {
                     secct.setId("fcst-" + sigmetUUID);
                     secct.setTimeIndicator(TimeIndicatorType.OBSERVATION);
-                    if (input.getAnalysisGeometries().get().get(0).getAnalysisType() == SigmetAnalysisType.FORECAST) {
+                    if (input.getAnalysisGeometries().get().get(0).getAnalysisType().orElse(null) == SigmetAnalysisType.FORECAST) {
                         secct.setTimeIndicator(TimeIndicatorType.FORECAST);
                     }
                     final int cnt = 0;

--- a/src/main/java/fi/fmi/avi/converter/iwxxm/v3_0/sigmet/SIGMETIWXXMSerializer.java
+++ b/src/main/java/fi/fmi/avi/converter/iwxxm/v3_0/sigmet/SIGMETIWXXMSerializer.java
@@ -383,7 +383,6 @@ public abstract class SIGMETIWXXMSerializer<T> extends AbstractIWXXM30Serializer
                     if (input.getVAInfo().isPresent()) {
                         noVaExp = input.getForecastGeometries().get().get(0).getNoVolcanicAshExpected().orElse(false);
                     }
-                    ;
                     JAXBElement<VolcanicAshSIGMETPositionCollectionType> fpa =
                             createVolcanicAshFPA(input.getForecastGeometries().get(), fcTime, noVaExp, volcanoId);
                     sigmet.getForecastPositionAnalysis().add(create(AssociationRoleType.class, at -> at.setAny(fpa)));
@@ -735,7 +734,6 @@ public abstract class SIGMETIWXXMSerializer<T> extends AbstractIWXXM30Serializer
                 target.setPermissibleUsage(PermissibleUsageType.NON_OPERATIONAL);
                 target.setPermissibleUsageReason(PermissibleUsageReasonType.TEST);
             }
-            ;
 
             if (source.isTranslated()) {
                 source.getTranslatedBulletinID().ifPresent(target::setTranslatedBulletinID);

--- a/src/test/java/fi/fmi/avi/converter/iwxxm/v2023_1/SIGMETIWWXXMSerializerTest.java
+++ b/src/test/java/fi/fmi/avi/converter/iwxxm/v2023_1/SIGMETIWWXXMSerializerTest.java
@@ -182,6 +182,11 @@ public class SIGMETIWWXXMSerializerTest {
         doTestSIGMETStringSerialization("sigmet_rdoact_cld.json", "sigmet_rdoact_cld.xml");
     }
 
+    @Test
+    public void testMinimalTest() throws Exception {
+        doTestSIGMETStringSerialization("sigmet_minimal_test.json", "sigmet_minimal_test.xml");
+    }
+
     public String doTestSIGMETStringSerialization(final String fn, final String iwxxmFn) throws Exception {
         assertTrue(converter.isSpecificationSupported(IWXXMConverter.SIGMET_POJO_TO_IWXXM2023_1_STRING));
         final SIGMET s = readFromJSON(fn);

--- a/src/test/java/fi/fmi/avi/converter/iwxxm/v3_0/SIGMETIWWXXMSerializerTest.java
+++ b/src/test/java/fi/fmi/avi/converter/iwxxm/v3_0/SIGMETIWWXXMSerializerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import fi.fmi.avi.converter.AviMessageConverter;
+import fi.fmi.avi.converter.ConversionIssue;
 import fi.fmi.avi.converter.ConversionResult;
 import fi.fmi.avi.converter.iwxxm.IWXXMTestConfiguration;
 import fi.fmi.avi.converter.iwxxm.conf.IWXXMConverter;
@@ -25,6 +26,8 @@ import java.nio.file.Paths;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = IWXXMTestConfiguration.class, loader = AnnotationConfigContextLoader.class)
@@ -192,14 +195,14 @@ public class SIGMETIWWXXMSerializerTest {
         final SIGMET s = readFromJSON(fn);
         final ConversionResult<String> result = converter.convertMessage(s, IWXXMConverter.SIGMET_POJO_TO_IWXXM30_STRING);
 
-//        for (ConversionIssue iss: result.getConversionIssues()) {
-//            System.err.println("iss:"+iss.getMessage()+"==="+iss.getCause());
-//        }
-//
-//        assertSame(ConversionResult.Status.SUCCESS, result.getStatus());
-//        System.err.println("XML:\n"+result.getConvertedMessage().get());
-//        assertTrue(result.getConvertedMessage().isPresent());
-//        assertNotNull(result.getConvertedMessage().get());
+        for (ConversionIssue iss : result.getConversionIssues()) {
+            System.err.println("iss:" + iss.getMessage() + "===" + iss.getCause());
+        }
+
+        assertSame(ConversionResult.Status.SUCCESS, result.getStatus());
+        System.err.println("XML:\n" + result.getConvertedMessage().get());
+        assertTrue(result.getConvertedMessage().isPresent());
+        assertNotNull(result.getConvertedMessage().get());
 
         String expectedXml = fixIds(readFromFile(iwxxmFn));
         assertEquals(expectedXml, fixIds(result.getConvertedMessage().get()));

--- a/src/test/java/fi/fmi/avi/converter/iwxxm/v3_0/SIGMETIWWXXMSerializerTest.java
+++ b/src/test/java/fi/fmi/avi/converter/iwxxm/v3_0/SIGMETIWWXXMSerializerTest.java
@@ -10,6 +10,7 @@ import fi.fmi.avi.converter.iwxxm.IWXXMTestConfiguration;
 import fi.fmi.avi.converter.iwxxm.conf.IWXXMConverter;
 import fi.fmi.avi.model.sigmet.SIGMET;
 import fi.fmi.avi.model.sigmet.immutable.SIGMETImpl;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -186,6 +187,7 @@ public class SIGMETIWWXXMSerializerTest {
     }
 
     @Test
+    @Ignore("Test sigmets without meteorological information cannot be represented in IWXXM 3.0")
     public void testMinimalTest() throws Exception {
         doTestSIGMETStringSerialization("sigmet_minimal_test.json", "sigmet_minimal_test.IWXXM30");
     }

--- a/src/test/java/fi/fmi/avi/converter/iwxxm/v3_0/SIGMETIWWXXMSerializerTest.java
+++ b/src/test/java/fi/fmi/avi/converter/iwxxm/v3_0/SIGMETIWWXXMSerializerTest.java
@@ -1,9 +1,20 @@
 package fi.fmi.avi.converter.iwxxm.v3_0;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertSame;
-import static junit.framework.TestCase.assertTrue;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import fi.fmi.avi.converter.AviMessageConverter;
+import fi.fmi.avi.converter.ConversionResult;
+import fi.fmi.avi.converter.iwxxm.IWXXMTestConfiguration;
+import fi.fmi.avi.converter.iwxxm.conf.IWXXMConverter;
+import fi.fmi.avi.model.sigmet.SIGMET;
+import fi.fmi.avi.model.sigmet.immutable.SIGMETImpl;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -12,24 +23,8 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.support.AnnotationConfigContextLoader;
-
-import fi.fmi.avi.converter.AviMessageConverter;
-import fi.fmi.avi.converter.ConversionIssue;
-import fi.fmi.avi.converter.ConversionResult;
-import fi.fmi.avi.converter.iwxxm.IWXXMTestConfiguration;
-import fi.fmi.avi.converter.iwxxm.conf.IWXXMConverter;
-import fi.fmi.avi.model.sigmet.SIGMET;
-import fi.fmi.avi.model.sigmet.immutable.SIGMETImpl;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = IWXXMTestConfiguration.class, loader = AnnotationConfigContextLoader.class)
@@ -187,19 +182,24 @@ public class SIGMETIWWXXMSerializerTest {
         doTestSIGMETStringSerialization("sigmet_FL_OPER.json", "sigmet_FL_OPER.IWXXM30");
     }
 
+    @Test
+    public void testMinimalTest() throws Exception {
+        doTestSIGMETStringSerialization("sigmet_minimal_test.json", "sigmet_minimal_test.IWXXM30");
+    }
+
     public String doTestSIGMETStringSerialization(final String fn, final String iwxxmFn) throws Exception {
         assertTrue(converter.isSpecificationSupported(IWXXMConverter.SIGMET_POJO_TO_IWXXM30_STRING));
         final SIGMET s = readFromJSON(fn);
         final ConversionResult<String> result = converter.convertMessage(s, IWXXMConverter.SIGMET_POJO_TO_IWXXM30_STRING);
 
-        for (ConversionIssue iss: result.getConversionIssues()) {
-            System.err.println("iss:"+iss.getMessage()+"==="+iss.getCause());
-        }
-
-        assertSame(ConversionResult.Status.SUCCESS, result.getStatus());
-        System.err.println("XML:\n"+result.getConvertedMessage().get());
-        assertTrue(result.getConvertedMessage().isPresent());
-        assertNotNull(result.getConvertedMessage().get());
+//        for (ConversionIssue iss: result.getConversionIssues()) {
+//            System.err.println("iss:"+iss.getMessage()+"==="+iss.getCause());
+//        }
+//
+//        assertSame(ConversionResult.Status.SUCCESS, result.getStatus());
+//        System.err.println("XML:\n"+result.getConvertedMessage().get());
+//        assertTrue(result.getConvertedMessage().isPresent());
+//        assertNotNull(result.getConvertedMessage().get());
 
         String expectedXml = fixIds(readFromFile(iwxxmFn));
         assertEquals(expectedXml, fixIds(result.getConvertedMessage().get()));

--- a/src/test/resources/fi/fmi/avi/converter/iwxxm/v2023_1/sigmet_minimal_test.json
+++ b/src/test/resources/fi/fmi/avi/converter/iwxxm/v2023_1/sigmet_minimal_test.json
@@ -1,0 +1,34 @@
+{
+  "reportStatus": "NORMAL",
+  "issuingAirTrafficServicesUnit": {
+    "name": "AMSTERDAM",
+    "type": "FIC",
+    "designator": "EHAA"
+  },
+  "meteorologicalWatchOffice": {
+    "name": "DE BILT",
+    "type": "MWO",
+    "designator": "EHDB"
+  },
+  "airspace": {
+    "designator": "EHAA",
+    "name": "AMSTERDAM FIR",
+    "type": "FIR"
+  },
+  "issueTime": {
+    "completeTime": "2023-10-03T11:25Z"
+  },
+  "validityPeriod": {
+    "startTime": {
+      "completeTime": "2023-10-03T11:30Z"
+    },
+    "endTime": {
+      "completeTime": "2023-10-03T15:30Z"
+    }
+  },
+  "sequenceNumber": "M01",
+  "translatedTAC": "EHAA SIGMET M01 VALID 111130/111530 EHDB-\r\nEHAA AMSTERDAM FIR TEST=",
+  "translated": false,
+  "permissibleUsage": "NON_OPERATIONAL",
+  "permissibleUsageReason": "TEST"
+}

--- a/src/test/resources/fi/fmi/avi/converter/iwxxm/v2023_1/sigmet_minimal_test.json
+++ b/src/test/resources/fi/fmi/avi/converter/iwxxm/v2023_1/sigmet_minimal_test.json
@@ -26,8 +26,8 @@
       "completeTime": "2023-10-03T15:30Z"
     }
   },
-  "sequenceNumber": "M01",
-  "translatedTAC": "EHAA SIGMET M01 VALID 111130/111530 EHDB-\r\nEHAA AMSTERDAM FIR TEST=",
+  "sequenceNumber": "Z01",
+  "translatedTAC": "EHAA SIGMET Z01 VALID 111130/111530 EHDB-\r\nEHAA AMSTERDAM FIR TEST=",
   "translated": false,
   "permissibleUsage": "NON_OPERATIONAL",
   "permissibleUsageReason": "TEST"

--- a/src/test/resources/fi/fmi/avi/converter/iwxxm/v2023_1/sigmet_minimal_test.xml
+++ b/src/test/resources/fi/fmi/avi/converter/iwxxm/v2023_1/sigmet_minimal_test.xml
@@ -53,7 +53,7 @@
          </aixm:timeSlice>
       </aixm:Airspace>
    </iwxxm:issuingAirTrafficServicesRegion>
-   <iwxxm:sequenceNumber>M01</iwxxm:sequenceNumber>
+   <iwxxm:sequenceNumber>Z01</iwxxm:sequenceNumber>
    <iwxxm:validPeriod>
       <gml:TimePeriod gml:id="uuid.548aae8a-73fb-4d40-b3b5-571561299840">
          <gml:beginPosition>2023-10-03T11:30:00Z</gml:beginPosition>

--- a/src/test/resources/fi/fmi/avi/converter/iwxxm/v2023_1/sigmet_minimal_test.xml
+++ b/src/test/resources/fi/fmi/avi/converter/iwxxm/v2023_1/sigmet_minimal_test.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iwxxm:SIGMET xmlns:iwxxm="http://icao.int/iwxxm/2023-1"
+              xmlns:gml="http://www.opengis.net/gml/3.2"
+              xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              gml:id="uuid.35bfb8c7-6390-42d8-b5e9-9b88055d1594"
+              isCancelReport="false"
+              permissibleUsage="NON-OPERATIONAL"
+              permissibleUsageReason="TEST"
+              reportStatus="NORMAL"
+              xsi:schemaLocation="http://icao.int/iwxxm/2023-1 http://schemas.wmo.int/iwxxm/2023-1/iwxxm.xsd">
+   <iwxxm:issueTime>
+      <gml:TimeInstant gml:id="uuid.4179613f-7632-47d3-8d23-3aa6439532ea">
+         <gml:timePosition>2023-10-03T11:25:00Z</gml:timePosition>
+      </gml:TimeInstant>
+   </iwxxm:issueTime>
+   <iwxxm:issuingAirTrafficServicesUnit>
+      <aixm:Unit gml:id="uuid.1c770f44-f1e9-4bd0-b84c-3ad35a7034e0">
+         <aixm:timeSlice>
+            <aixm:UnitTimeSlice gml:id="uuid.89ea1c12-1651-4280-b0da-afe5fe71920b">
+               <gml:validTime/>
+               <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+               <aixm:name>AMSTERDAM</aixm:name>
+               <aixm:type>FIC</aixm:type>
+               <aixm:designator>EHAA</aixm:designator>
+            </aixm:UnitTimeSlice>
+         </aixm:timeSlice>
+      </aixm:Unit>
+   </iwxxm:issuingAirTrafficServicesUnit>
+   <iwxxm:originatingMeteorologicalWatchOffice>
+      <aixm:Unit gml:id="uuid.d2f66f9a-a0f1-4500-b266-d49f75be3f1d">
+         <aixm:timeSlice>
+            <aixm:UnitTimeSlice gml:id="uuid.f6a6e135-9958-498f-ad89-a84d4a95c476">
+               <gml:validTime/>
+               <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+               <aixm:name>DE BILT</aixm:name>
+               <aixm:type>MWO</aixm:type>
+               <aixm:designator>EHDB</aixm:designator>
+            </aixm:UnitTimeSlice>
+         </aixm:timeSlice>
+      </aixm:Unit>
+   </iwxxm:originatingMeteorologicalWatchOffice>
+   <iwxxm:issuingAirTrafficServicesRegion>
+      <aixm:Airspace gml:id="uuid.cea2deb3-d242-48c0-be32-349476a27169">
+         <aixm:timeSlice>
+            <aixm:AirspaceTimeSlice gml:id="uuid.56160db0-52fa-4a79-b060-67fd21404dd7">
+               <gml:validTime/>
+               <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+               <aixm:type>FIR</aixm:type>
+               <aixm:designator>EHAA</aixm:designator>
+               <aixm:name>AMSTERDAM FIR</aixm:name>
+            </aixm:AirspaceTimeSlice>
+         </aixm:timeSlice>
+      </aixm:Airspace>
+   </iwxxm:issuingAirTrafficServicesRegion>
+   <iwxxm:sequenceNumber>M01</iwxxm:sequenceNumber>
+   <iwxxm:validPeriod>
+      <gml:TimePeriod gml:id="uuid.548aae8a-73fb-4d40-b3b5-571561299840">
+         <gml:beginPosition>2023-10-03T11:30:00Z</gml:beginPosition>
+         <gml:endPosition>2023-10-03T15:30:00Z</gml:endPosition>
+      </gml:TimePeriod>
+   </iwxxm:validPeriod>
+</iwxxm:SIGMET>

--- a/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/sigmet_minimal_test.IWXXM30
+++ b/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/sigmet_minimal_test.IWXXM30
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iwxxm:SIGMET xmlns:iwxxm="http://icao.int/iwxxm/3.0"
+              xmlns:gml="http://www.opengis.net/gml/3.2"
+              xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              gml:id="GMLID"
+              isCancelReport="false"
+              permissibleUsage="NON-OPERATIONAL"
+              permissibleUsageReason="TEST"
+              reportStatus="NORMAL"
+              xsi:schemaLocation="http://icao.int/iwxxm/3.0 http://schemas.wmo.int/iwxxm/3.0/iwxxm.xsd">
+   <iwxxm:issueTime>
+      <gml:TimeInstant gml:id="GMLID">
+         <gml:timePosition>2023-10-03T11:25:00Z</gml:timePosition>
+      </gml:TimeInstant>
+   </iwxxm:issueTime>
+   <iwxxm:issuingAirTrafficServicesUnit>
+      <aixm:Unit gml:id="GMLID">
+         <aixm:timeSlice>
+            <aixm:UnitTimeSlice gml:id="GMLID">
+               <gml:validTime/>
+               <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+               <aixm:name>AMSTERDAM</aixm:name>
+               <aixm:type>FIC</aixm:type>
+               <aixm:designator>EHAA</aixm:designator>
+            </aixm:UnitTimeSlice>
+         </aixm:timeSlice>
+      </aixm:Unit>
+   </iwxxm:issuingAirTrafficServicesUnit>
+   <iwxxm:originatingMeteorologicalWatchOffice>
+      <aixm:Unit gml:id="GMLID">
+         <aixm:timeSlice>
+            <aixm:UnitTimeSlice gml:id="GMLID">
+               <gml:validTime/>
+               <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+               <aixm:name>DE BILT</aixm:name>
+               <aixm:type>MWO</aixm:type>
+               <aixm:designator>EHDB</aixm:designator>
+            </aixm:UnitTimeSlice>
+         </aixm:timeSlice>
+      </aixm:Unit>
+   </iwxxm:originatingMeteorologicalWatchOffice>
+   <iwxxm:issuingAirTrafficServicesRegion>
+      <aixm:Airspace gml:id="GMLID">
+         <aixm:timeSlice>
+            <aixm:AirspaceTimeSlice gml:id="GMLID">
+               <gml:validTime/>
+               <aixm:interpretation>SNAPSHOT</aixm:interpretation>
+               <aixm:type>FIR</aixm:type>
+               <aixm:designator>EHAA</aixm:designator>
+               <aixm:name>AMSTERDAM FIR</aixm:name>
+            </aixm:AirspaceTimeSlice>
+         </aixm:timeSlice>
+      </aixm:Airspace>
+   </iwxxm:issuingAirTrafficServicesRegion>
+   <iwxxm:sequenceNumber>M01</iwxxm:sequenceNumber>
+   <iwxxm:validPeriod>
+      <gml:TimePeriod gml:id="GMLID">
+         <gml:beginPosition>2023-10-03T11:30:00Z</gml:beginPosition>
+         <gml:endPosition>2023-10-03T15:30:00Z</gml:endPosition>
+      </gml:TimePeriod>
+   </iwxxm:validPeriod>
+</iwxxm:SIGMET>

--- a/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/sigmet_minimal_test.json
+++ b/src/test/resources/fi/fmi/avi/converter/iwxxm/v3_0/sigmet_minimal_test.json
@@ -1,0 +1,34 @@
+{
+  "reportStatus": "NORMAL",
+  "issuingAirTrafficServicesUnit": {
+    "name": "AMSTERDAM",
+    "type": "FIC",
+    "designator": "EHAA"
+  },
+  "meteorologicalWatchOffice": {
+    "name": "DE BILT",
+    "type": "MWO",
+    "designator": "EHDB"
+  },
+  "airspace": {
+    "designator": "EHAA",
+    "name": "AMSTERDAM FIR",
+    "type": "FIR"
+  },
+  "issueTime": {
+    "completeTime": "2023-10-03T11:25Z"
+  },
+  "validityPeriod": {
+    "startTime": {
+      "completeTime": "2023-10-03T11:30Z"
+    },
+    "endTime": {
+      "completeTime": "2023-10-03T15:30Z"
+    }
+  },
+  "sequenceNumber": "M01",
+  "translatedTAC": "EHAA SIGMET M01 VALID 111130/111530 EHDB-\r\nEHAA AMSTERDAM FIR TEST=",
+  "translated": false,
+  "permissibleUsage": "NON_OPERATIONAL",
+  "permissibleUsageReason": "TEST"
+}


### PR DESCRIPTION
Made analysis type optional to support minimal test sigmets/airmets. Note that there's currently no way to differentiate between standard sigmets, volcanic ash sigmets or tropical cyclone sigmets when using short test sigmets without meteorological information. Follow up: https://github.com/fmidev/fmi-avi-messageconverter-tac/issues/184.